### PR TITLE
Public/OderのURL修正、エラーメッセージ、サクセスメッセージ修正

### DIFF
--- a/app/controllers/admins/customers_controller.rb
+++ b/app/controllers/admins/customers_controller.rb
@@ -15,8 +15,7 @@ class Admins::CustomersController < ApplicationController
   def update
     @customer = Customer.find(params[:id])
     if @customer.update(customer_params)
-      redirect_to admins_customer_path(@customer.id),
-      flash:{notice:'You have updated customer info successfully.'}
+      redirect_to admins_customer_path(@customer.id),flash:{notice:'登録情報を編集しました。'}
     else
       render 'edit'
     end

--- a/app/controllers/admins/genres_controller.rb
+++ b/app/controllers/admins/genres_controller.rb
@@ -8,7 +8,7 @@ class Admins::GenresController < ApplicationController
   def create
     @genre = Genre.new(genre_params)
     if @genre.save
-    redirect_to admins_genres_path
+    redirect_to admins_genres_path,flash:{notice:'新規ジャンルを登録しました。'}
     else
       @genres = Genre.all
       render "index"
@@ -22,7 +22,7 @@ class Admins::GenresController < ApplicationController
   def update
     @genre = Genre.find(params[:id])
     if @genre.update(genre_params)
-    redirect_to admins_genres_path
+    redirect_to admins_genres_path,flash:{notice:'ジャンルを編集しました。'}
     else
       render "edit"
     end

--- a/app/controllers/admins/items_controller.rb
+++ b/app/controllers/admins/items_controller.rb
@@ -6,7 +6,7 @@ class Admins::ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     if @item.save
-      redirect_to admins_items_path,flash:{notice:'新規商品の登録に成功しました。'}
+      redirect_to admins_items_path,flash:{notice:'新規商品を登録しました。'}
     else
       render "new"
     end
@@ -28,7 +28,7 @@ class Admins::ItemsController < ApplicationController
   def update
     @item = Item.find(params[:id])
     if @item.update(item_params)
-      redirect_to admins_items_path,flash:{notice:'商品の変更に成功しました。'}
+      redirect_to admins_items_path,flash:{notice:'商品を変更しました。'}
     else
       render "edit"
     end

--- a/app/controllers/public/addresses_controller.rb
+++ b/app/controllers/public/addresses_controller.rb
@@ -4,7 +4,7 @@ class Public::AddressesController < ApplicationController
     @address = Address.new(address_params)
     @address.customer_id = current_customer.id
     if @address.save
-    redirect_to request.referer
+    redirect_to request.referer,flash:{notice:'新規お届け先を登録しました。'}
     else
       @addresses = current_customer.addresses
       render "index"
@@ -24,7 +24,7 @@ class Public::AddressesController < ApplicationController
   def update
     @address = Address.find(params[:id])
     if @address.update(address_params)
-    redirect_to addresses_path
+    redirect_to addresses_path,flash:{notice:'お届け先の編集をしました。'}
     else
       render "edit"
     end
@@ -33,7 +33,7 @@ class Public::AddressesController < ApplicationController
   def destroy
     @address = Address.find(params[:id])
     @address.destroy
-    redirect_to addresses_path
+    redirect_to addresses_path,flash:{notice:'お届け先を削除しました。'}
   end
 
   private

--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -17,7 +17,7 @@ class Public::CartItemsController < ApplicationController
        @cart_item.save
        redirect_to cart_items_path
      else
-       redirect_to public_item_path(@cart_item.item.id), notice: "数量を入力してください"
+      redirect_to public_item_path(@cart_item.item.id), alert: "数量を入力してください"
      end
   end
 
@@ -30,7 +30,7 @@ class Public::CartItemsController < ApplicationController
    if @cart_item.update(cart_item_params)
    redirect_to cart_items_path
    else
-   redirect_to cart_items_path, notice: "数量を入力してください"
+   redirect_to cart_items_path, alert: "数量を入力してください"
    end
  end
 

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -14,7 +14,7 @@ class Public::CustomersController < ApplicationController
     # @customer = Customer.find(params[:id])
      @customer = current_customer
     if @customer.update(customer_params)
-    redirect_to  customers_my_page_path(@customer)
+    redirect_to  customers_my_page_path(@customer),flash:{notice:'登録情報を編集しました。'}
     else
     render "edit"
     end

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -1,5 +1,7 @@
 class Public::OrdersController < ApplicationController
   def new
+    @cart_items = current_customer.cart_items
+    if @cart_items.present?
     @order = Order.new
     # 登録済み住所選択プルダンに使用
     @addresses = Address.where(customer: current_customer)
@@ -7,6 +9,9 @@ class Public::OrdersController < ApplicationController
     # @new_address = @order.address
     # @new_postal_code = @order.postal_code
     # @new_name = @order.name
+    else
+    redirect_to cart_items_path,flash:{notice:'カートに商品が入っていません。'}
+    end
   end
 
 
@@ -33,6 +38,15 @@ class Public::OrdersController < ApplicationController
       @order.postal_code = params[:order][:new_postal_code]
       @order.address = params[:order][:new_address]
       @order.name = params[:order][:new_name]
+
+      # 郵便番号、住所、氏名がどれかでも抜けていればrenderする条件式12/24タネサカ
+      unless
+        @order.postal_code.present? & @order.address.present? & @order.address.present?
+        @addresses = Address.where(customer: current_customer)
+        flash.now[:alert] = "お届け先が入力されていませんでした。再度支払方法からご入力ください。"
+        render "new"
+      end
+
     end
 
   end
@@ -50,7 +64,7 @@ class Public::OrdersController < ApplicationController
         @order_details.save
      end
    current_customer.cart_items.destroy_all
-   redirect_to  complete_public_orders_path
+   redirect_to  complete_orders_path
   end
 
   def index

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,8 +1,8 @@
 class Item < ApplicationRecord
     attachment :image
-    validates :name, :genre_id, :introduction, :image, :price, :is_active, presence: true
-
+    validates :name, :genre_id, :introduction, :image, :price, presence: true
+    validates :is_active, inclusion: { in: [true, false] }
     belongs_to :genre
     has_many :cart_items
-    has_many :order_de
+    has_many :order_details
 end

--- a/app/views/admins/items/edit.html.erb
+++ b/app/views/admins/items/edit.html.erb
@@ -1,4 +1,5 @@
 <h1>商品編集ページ</h1>
+<%= render "layouts/error_messages", resource: @item %>
 <%= form_with model:@item, url: admins_item_path(@item.id), method: :patch, local:true do |f| %>
     <p>商品写真</p>
     <%= f.attachment_field :image %>
@@ -12,6 +13,6 @@
     <%= f.number_field :price %>
     <p>販売ステータス</p>
     <%= f.select :is_active, [['販売中',0],['販売停止',1]],{ include_blank: true, selected: 0 } %>
-    
+
     <%= f.submit '商品編集', class:"btn btn-secondary" %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,9 +11,20 @@
   </head>
 
   <body>
-  
+
   <%= render 'layouts/header' %>
+
+  <% if notice.present? %>
+<h3 class="alert alert-success">
   <%= flash[:notice] %>
+  </h3>
+<% end %>
+
+  <% if alert.present? %>
+<h3 class="alert alert-danger">
+  <%= flash[:alert] %>
+  </h3>
+<% end %>
 
     <%= yield %>
   </body>

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -1,11 +1,5 @@
+
 <h4 style="margin:40px 150px;"><span class="alert-dark pl-3 pr-3">ショッピングカート</span>
-<!--エラーメッセージ風notice-->
-<% if notice.present? %>
-<h3 class="alert alert-danger">
- <%= notice %>
-</h3>
-<% end %>
-<!--ここまで-->
   <span style="margin-left:640px;"><%= link_to "カートを空にする", destroy_all_cart_items_path, method: :delete, class:"btn btn-danger" %></span></h4>
 <table class="table table-bordered col-md-9 offset-md-1">
   <thead>
@@ -46,4 +40,4 @@
   </thead>
 </table>
     <p><%= link_to "買い物を続ける", public_items_path, class:"btn btn-primary active" %></p>
-    <p><%= link_to "情報入力に進む", new_public_order_path, class:"btn btn-primary active" %></p>
+    <p><%= link_to "情報入力に進む", new_order_path, class:"btn btn-primary active" %></p>

--- a/app/views/public/customers/show.html.erb
+++ b/app/views/public/customers/show.html.erb
@@ -49,4 +49,4 @@
       </tbody>
 </table>
   <h3 class="ml-5 mt-4">配送先<span style="margin-left:20px;"><%= link_to "一覧を見る", addresses_path(current_customer), class:" btn btn-primary active pl-4 pr-4" %></span></h3>
- <h3 class="ml-5 mt-4">注文履歴<span style="margin-left:20px;"><%= link_to "一覧を見る", public_orders_path, class:" btn btn-primary active pl-4 pr-4" %></span></h3>
+ <h3 class="ml-5 mt-4">注文履歴<span style="margin-left:20px;"><%= link_to "一覧を見る", orders_path, class:" btn btn-primary active pl-4 pr-4" %></span></h3>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -1,13 +1,5 @@
 <h1>商品詳細ページ（利用者）</h1>
 
-<!--エラーメッセージ風notice-->
-<% if notice.present? %>
-<h3 class="alert alert-danger">
- <%= notice %>
-</h3>
-<% end %>
-<!--ここまで-->
-
 <table class="table table-bordered genre-table">
     <thead>
       <tr>

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -50,7 +50,7 @@
 <p> <%= "#{@order.postal_code} #{@order.address} 　#{@order.name}" %></p>
 
 
-<%= form_with model:@order, url: public_orders_path,method: :post, local:true do |f| %>
+<%= form_with model:@order, url: orders_path,method: :post, local:true do |f| %>
 <%= f.hidden_field :postal_code, value: @order.postal_code %>
 <%= f.hidden_field :address, value: @order.address %>
 <%= f.hidden_field :name, value: @order.name %>

--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -35,7 +35,7 @@
     		          <%= order.status %>
     		        </td>
          	      <td>
-       	          <%= link_to "注文詳細", public_order_path(order.id), class: "glyphicon glyphicon-zoom-in btn btn-success" %>
+       	          <%= link_to "注文詳細", order_path(order.id), class: "glyphicon glyphicon-zoom-in btn btn-success" %>
        	        </td>
               </tr>
             <% end %>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -1,5 +1,5 @@
 <h1>注文情報入力ページ</h1>
-<%= form_with model:@order, url: confirm_public_orders_path,method: :get, local:true do |f| %>
+<%= form_with model:@order, url: confirm_orders_path,method: :get, local:true do |f| %>
 
 
 <!--支払方法-->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  
+
   namespace :public do
     resources :items, only:[:index,  :show]
   end
@@ -71,14 +71,14 @@ resources :cart_items, only:[:index, :create, :update, :destroy] do
     resources :addresses, only:[:index, :create, :edit, :update, :destroy]
   end
 
-  namespace :public do
+  scope module: :public do
     resources :orders, only:[:index, :new, :show, :create] do
       collection  do
         get :complete
         get :confirm
       end
     end
-  end  
+  end
 
 
 


### PR DESCRIPTION
・Public/OderのURL修正
・エラー表示させるの抜けている部分があったので追加しました。
※カートが空の状態で注文情報入力に進む
※納品先情報を別途入力する際、空欄で注文確認画面に進む（ここの条件分岐は
    unless
        @order.postal_code.present? & @order.address.present? & @order.address.present?
で行いました。ordersコントローラー参照）

・サクセスメッセージとエラーアラートでレイアウトを分けました。
※noticeと同じ使い方ができるalert　がありました。今回alertをエラーメッセージレイアウトに合わせています（各コントローラー及び、アプリケーションHTML参照）。


お手数をおかけしますがご確認のほどお願いいたします。